### PR TITLE
Fix dup mutating original store

### DIFF
--- a/lib/attributed_string/klass.rb
+++ b/lib/attributed_string/klass.rb
@@ -20,8 +20,9 @@ class AttributedString < String
   def dup
     super.tap do |copy|
       new_store = @store.map do |entry|
-        entry[:range] = entry[:range].dup
-        entry.dup
+        entry_dup = entry.dup
+        entry_dup[:range] = entry_dup[:range].dup
+        entry_dup
       end
       copy.instance_variable_set(:@store, new_store)
     end

--- a/test/initializers_test.rb
+++ b/test/initializers_test.rb
@@ -24,4 +24,12 @@ class InitializersTest < Minitest::Test
     end
   end
 
+  def test_dup_does_not_modify_original_store
+    @attr_string.add_attrs(0..4, bold: true)
+    original_range_id = @attr_string.instance_variable_get(:@store).first[:range].object_id
+    @attr_string.dup
+    after_range_id = @attr_string.instance_variable_get(:@store).first[:range].object_id
+    assert_equal original_range_id, after_range_id
+  end
+
 end


### PR DESCRIPTION
## Summary
- prevent `AttributedString#dup` from modifying the original object's store
- add regression test

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6849612a82888320b78599923b619259