### PR TITLE
Use span iterator for inspect and better tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ Add this line to your application's Gemfile:
   puts hello_world.attachments # => []
 ```
 
+## Iterating Over Attribute Spans
+
+`each_span_with_attrs` yields substrings where the active attributes do not
+change. This allows efficient traversal of long strings with many attribute
+ranges.
+
+```ruby
+  str = AttributedString.new('hello')
+  str.add_attrs(0..1, bold: true)
+  str.add_attrs(2..4, italic: true)
+
+  str.each_span_with_attrs do |substring, attrs, range|
+    p [substring, attrs, range]
+  end
+  # => ["he", { bold: true }, 0..1]
+  # => ["l", {}, 2..2]
+  # => ["lo", { italic: true }, 3..4]
+```
+
 ## More Examples
 See the [test suite](./test).
 

--- a/lib/attributed_string/attachment.rb
+++ b/lib/attributed_string/attachment.rb
@@ -53,14 +53,13 @@ class AttributedString < String
     attachments_with_positions(range: range).map { |attachment| attachment[:attachment] }
   end
 
-  # TODO: needs a test
   def attachments_with_positions(range: 0...self.length)
     range = normalize_range(range)
     return [] if range.nil?
-    attachments = []
-    self.chars[range].map.with_index do |char, i|
-      attachments << { attachment: attachment_at(range.begin + i), position: range.begin + i } if char == ATTACHMENT_CHARACTER
+    @store.each_with_object([]) do |entry, arr|
+      if entry[:attachment] && range.include?(entry[:range].begin)
+        arr << { attachment: entry[:attachment], position: entry[:range].begin }
+      end
     end
-    attachments
   end
 end

--- a/lib/attributed_string/filter_result.rb
+++ b/lib/attributed_string/filter_result.rb
@@ -16,52 +16,31 @@ class AttributedString < String
   class FilterResult < String
     # @see AttributedString#filter
     def initialize(attr_string, &block)
-      filtered_positions = []
+      result_parts = []
+      ranges = []
       cached_block_calls = {}
 
-      # TODO: this can be optimized to use the same method that inspect uses which doesn't go through
-      # every character (it goes through each substring span with different ranges)
-      # A presenter type architecture that inspect, rainbow print, and filter can share would be ideal
-      attr_string.each_char.with_index do |char, index|
-        attrs = attr_string.attrs_at(index)
-        # Use the attrs object ID as the cache key to handle different attribute hashes
+      attr_string.each_span_with_attrs do |substring, attrs, range|
         cache_key = attrs.hash
-        cached_result = cached_block_calls.fetch(cache_key) do
-          result = block.call(attrs)
-          cached_block_calls[cache_key] = result
-          result
+        keep = cached_block_calls.fetch(cache_key) do
+          res = block.call(attrs)
+          cached_block_calls[cache_key] = res
+          res
         end
-        if cached_result
-          filtered_positions << index
+        next unless keep
+
+        result_parts << substring
+
+        if ranges.any? && ranges.last.end == range.begin - 1
+          last = ranges.pop
+          ranges << (last.begin..range.end)
+        else
+          ranges << range
         end
       end
 
-      # Group adjacent positions into ranges to minimize allocations
-      ranges = []
-      unless filtered_positions.empty?
-        start_pos = filtered_positions.first
-        prev_pos = start_pos
-        filtered_positions.each_with_index do |pos, idx|
-          next if idx == 0
-          if pos == prev_pos + 1
-            # Continue the current range
-            prev_pos = pos
-          else
-            # End the current range and start a new one
-            ranges << (start_pos..prev_pos)
-            start_pos = pos
-            prev_pos = pos
-          end
-        end
-        # Add the final range
-        ranges << (start_pos..prev_pos)
-      end
-
-      # Concatenate substrings from the original string based on the ranges
-      result_string = ranges.map { |range| attr_string.send(:original_slice,range) }.join
-
-      # Build the list of original positions
-      original_positions = ranges.flat_map { |range| range.to_a }
+      result_string = result_parts.join
+      original_positions = ranges.flat_map { |r| r.to_a }
 
       super(result_string)
       @original_positions = original_positions
@@ -73,14 +52,15 @@ class AttributedString < String
     end
 
     def original_ranges_for(filtered_range)
-      # TODO: this doesn't work for excluded end range
       raise ArgumentError, "Invalid range" unless filtered_range.is_a?(Range)
-      raise ArgumentError, "Range out of bounds" if filtered_range.end >= length
-      if filtered_range.begin > filtered_range.end
+
+      end_idx = filtered_range.end
+      end_idx -= 1 if filtered_range.exclude_end?
+      raise ArgumentError, "Range out of bounds" if end_idx >= length
+
+      if filtered_range.begin > end_idx
+        return [] if filtered_range.begin == end_idx + 1 && filtered_range.exclude_end?
         raise ArgumentError, "Reverse range is not allowed"
-      end
-      if filtered_range.begin == filtered_range.end && filtered_range.exclude_end?
-        return []
       end
 
       original_positions = @original_positions[filtered_range]

--- a/lib/attributed_string/inspect.rb
+++ b/lib/attributed_string/inspect.rb
@@ -9,87 +9,58 @@ class AttributedString
 #   "and these have none").inspect
 #
   def inspect(color: false)
-    # Collect all positions where attributes change
-    positions = Set.new
-
-    @store.each do |attr|
-      range = attr[:range]
-      positions << range.begin
-      positions << range.begin + range.size
+    attachments_map = attachments_with_positions(range: 0...length).each_with_object({}) do |entry, h|
+      h[entry[:position]] = entry[:attachment]
     end
 
-    # Include the start and end positions of the string
-    positions << 0
-    positions << self.length
-
-    # Sort all positions
-    positions = positions.to_a.sort
-
     result = ""
-    last_attrs = {}  # Initialize as empty hash
+    last_attrs = {}
 
-    positions.each_cons(2) do |start_pos, end_pos|
-      next if start_pos >= end_pos  # Skip invalid ranges
-
-      substring = self.to_s[start_pos...end_pos]
-      attrs_before = last_attrs
-      attachment = attachment_at(start_pos)
-      attrs_after = attrs_at(start_pos)
-
-      # Determine attribute changes
+    each_span_with_attrs do |substring, attrs, range|
       ended_attrs = {}
       started_attrs = {}
 
-      # Attributes that have ended or changed
-      attrs_before.each do |key, value|
-        if !attrs_after.key?(key)
-          # Attribute has ended
+      last_attrs.each do |key, value|
+        if !attrs.key?(key)
           ended_attrs[key] = value
-        elsif attrs_after[key] != value
-          # Attribute value has changed; treat as ending old and starting new
+        elsif attrs[key] != value
           ended_attrs[key] = value
-          started_attrs[key] = attrs_after[key]
+          started_attrs[key] = attrs[key]
         end
       end
 
-      # Attributes that have started
-      attrs_after.each do |key, value|
-        if !attrs_before.key?(key)
-          started_attrs[key] = value
-        end
+      attrs.each do |key, value|
+        started_attrs[key] = value unless last_attrs.key?(key)
       end
 
-      # Remove attributes that both ended and started (value change)
       ended_attrs.delete_if { |k, _| started_attrs.key?(k) }
 
       unless ended_attrs.empty? && started_attrs.empty?
-        attrs_str = ended_attrs.keys.sort.map{ |k| "-#{k}" }
-        attrs_str += started_attrs.to_a.sort{ |a,b| a[0] <=> b[0] }.map{ |a| "#{a[0]}: #{a[1]}" }
-        attrs_str = "{ #{attrs_str.join(', ')} }"
-        result += dim(attrs_str, color: color)
+        attrs_str = ended_attrs.keys.sort.map { |k| "-#{k}" }
+        attrs_str += started_attrs.sort_by { |a, _| a }.map { |k, v| "#{k}: #{v}" }
+        result << dim("{ #{attrs_str.join(', ')} }", color: color)
       end
 
-      if attachment
-        substring = dim("[#{attachment}]", color: color)
+      substring.chars.each_with_index do |char, i|
+        pos = range.begin + i
+        if char.to_s == ATTACHMENT_CHARACTER && attachments_map.key?(pos)
+          result << dim("[#{attachments_map[pos]}]", color: color)
+        else
+          result << char
+        end
       end
 
-      # Append the substring
-      result += substring
-
-      last_attrs = attrs_after
+      last_attrs = attrs
     end
 
-    # Close any remaining attributes
     unless last_attrs.empty?
-      result += dim("{ #{last_attrs.keys.sort.map{ |k| "-#{k}" }.join(", ")} }", color: color)
+      result << dim("{ #{last_attrs.keys.sort.map { |k| "-#{k}" }.join(', ')} }", color: color)
     end
 
     result
   end
 
-
   def dim(string, color: true)
     color ? "\e[2m#{string}\e[22m" : string
   end
-
 end

--- a/lib/attributed_string/klass.rb
+++ b/lib/attributed_string/klass.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 class AttributedString < String
 
   alias_method :original_slice, :slice
@@ -105,6 +107,107 @@ class AttributedString < String
     return false unless other.is_a?(AttributedString)
     # not super efficient, but it works for now
     (0...length).all? { |i| attrs_at(i) == other.attrs_at(i) && attachment_at(i) == other.attachment_at(i) } && super
+  end
+
+  # Iterates over contiguous spans of the string that share the same active
+  # attributes. Yields the substring, the attributes for that span, and the
+  # span range. This avoids yielding once per character and instead jumps
+  # directly to points where attributes change, allowing callers to operate in
+  # O(n + k) time where `n` is the number of attribute ranges and `k` is the
+  # resulting span count.
+  def each_span_with_attrs
+    return enum_for(:each_span_with_attrs) unless block_given?
+
+    starts, ends = build_attr_events
+    positions = ([0, length] + starts.keys + ends.keys).uniq.sort
+
+    active = Hash.new { |h, k| h[k] = [] }
+    attrs  = {}
+
+    positions.each_cons(2) do |span_start, span_end|
+      starts[span_start]&.each { |entry| apply_event(entry, active, attrs) }
+
+      substring = original_slice(span_start...span_end)
+      yield substring, attrs.dup, span_start..(span_end - 1)
+
+      ends[span_end]&.each { |entry| remove_event(entry, active, attrs) }
+    end
+  end
+
+  private
+
+  def build_attr_events
+    starts = Hash.new { |h, k| h[k] = [] }
+    ends   = Hash.new { |h, k| h[k] = [] }
+    @store.each do |entry|
+      next unless entry[:range]
+      next if entry[:attachment]
+      range = entry[:range]
+      starts[range.begin] << entry
+      finish = range.end + 1
+      ends[finish] << entry if finish <= length
+    end
+    [starts, ends]
+  end
+
+  def apply_event(entry, stacks, attrs)
+    if entry[:attributes]
+      entry[:attributes].each do |k, v|
+        stacks[k] << [entry, v]
+        attrs[k] = current_value(stacks[k])
+      end
+    elsif entry[:arr_attributes]
+      entry[:arr_attributes].each do |k, v|
+        stacks[k] << [entry, Array(v)]
+        attrs[k] = current_value(stacks[k])
+      end
+    elsif entry[:delete]
+      entry[:delete].each do |k|
+        stacks[k] << [entry, :__deleted__]
+        attrs.delete(k)
+      end
+    end
+  end
+
+  def remove_event(entry, stacks, attrs)
+    keys = if entry[:attributes]
+              entry[:attributes].keys
+            elsif entry[:arr_attributes]
+              entry[:arr_attributes].keys
+            else
+              entry[:delete]
+            end
+    keys.each do |k|
+      stack = stacks[k]
+      next unless stack
+      idx = stack.index { |e, _| e.equal?(entry) }
+      next unless idx
+      stack.delete_at(idx)
+      if stack.empty?
+        stacks.delete(k)
+        attrs.delete(k)
+      else
+        val = current_value(stack)
+        val.nil? ? attrs.delete(k) : attrs[k] = val
+      end
+    end
+  end
+
+  def current_value(stack)
+    return nil if stack.empty?
+    if stack.any? { |_, v| v.is_a?(Array) }
+      values = []
+      stack.each { |_, v| values.concat(v) unless v == :__deleted__ }
+      values.empty? ? nil : values
+    else
+      val = nil
+      stack.reverse_each do |_, v|
+        next if v == :__deleted__
+        val = v
+        break
+      end
+      val
+    end
   end
 
 

--- a/test/attachment_test.rb
+++ b/test/attachment_test.rb
@@ -70,4 +70,22 @@ class AddingAttachmentTest < Minitest::Test
     assert_equal "attachment", str.attachment_at(2)
     assert_nil str.attachment_at(3)
   end
+
+  def test_attachments_with_positions_entire_string
+    @str.add_attachment("second", position: 3)
+    results = @str.attachments_with_positions
+    assert_equal [{ attachment: "attachment", position: 1 },
+                  { attachment: "second", position: 3 }], results
+  end
+
+  def test_attachments_with_positions_in_range
+    @str.add_attachment("second", position: 3)
+    results = @str.attachments_with_positions(range: 3..3)
+    assert_equal [{ attachment: "second", position: 3 }], results
+  end
+
+  def test_attachments_with_positions_invalid_range
+    results = @str.attachments_with_positions(range: 100..101)
+    assert_equal [], results
+  end
 end

--- a/test/benchmark_performance_test.rb
+++ b/test/benchmark_performance_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+require 'minitest/benchmark'
+
+# Benchmarks for common AttributedString operations. These tests help
+# identify operations that scale worse than linearly as the string or
+# attribute count grows.
+class BenchmarkPerformanceTest < Minitest::Benchmark
+  # Use a modest range so the test suite stays fast while still
+  # demonstrating growth trends.
+  def self.bench_range
+    bench_exp(10, 1_000, 10)
+  end
+
+  # Benchmark adding a single attribute over the entire string.
+  # The operation should run in roughly constant time with respect to string
+  # length because only the attribute list grows by one entry.
+  def bench_add_attrs_whole_string
+    assert_performance_constant do |n|
+      str = AttributedString.new('a' * n)
+      str.add_attrs(0...n, bold: true)
+    end
+  end
+
+  # Benchmark looking up an attribute when many single-character ranges exist.
+  def bench_attrs_at_many_ranges
+    assert_performance_linear 0.90 do |n|
+      str = AttributedString.new('a' * n)
+      n.times { |i| str.add_attrs(i..i, index: i) }
+      str.attrs_at(n / 2)
+    end
+  end
+
+  # Benchmark inserting text in the middle of a heavily attributed string.
+  def bench_insert_middle
+    assert_performance_linear 0.90 do |n|
+      str = AttributedString.new('a' * n)
+      n.times { |i| str.add_attrs(i..i, index: i) }
+      str.insert(n / 2, 'b')
+    end
+  end
+
+  # Benchmark iterating over spans with many small attribute ranges.
+  def bench_each_span_with_attrs
+    assert_performance_linear 0.90 do |n|
+      str = AttributedString.new('a' * n)
+      n.times { |i| str.add_attrs(i..i, index: i) }
+      str.each_span_with_attrs { |_sub, _attrs, _range| }
+    end
+  end
+
+  # Benchmark filtering to build a new AttributedString when densely attributed.
+  def bench_filter_dense
+    assert_performance_linear 0.90 do |n|
+      str = AttributedString.new('a' * n)
+      n.times { |i| str.add_attrs(i..i, index: i) }
+      str.filter { |attrs| attrs[:index].even? }
+    end
+  end
+
+  # Benchmark inspect on a heavily attributed string.
+  def bench_inspect_dense
+    assert_performance_linear 0.90 do |n|
+      str = AttributedString.new('a' * n)
+      n.times { |i| str.add_attrs(i..i, index: i) }
+      str.inspect
+    end
+  end
+end

--- a/test/each_span_with_attrs_test.rb
+++ b/test/each_span_with_attrs_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+
+class EachSpanWithAttrsTest < Minitest::Test
+  def test_yields_spans_and_attributes
+    str = AttributedString.new('Hello')
+    str.add_attrs(0..1, bold: true)
+    str.add_attrs(3..4, italic: true)
+
+    spans = str.each_span_with_attrs.to_a
+    assert_equal [
+      ['He', { bold: true }, 0..1],
+      ['l', {}, 2..2],
+      ['lo', { italic: true }, 3..4]
+    ], spans
+  end
+
+  def test_attribute_removal_creates_new_span
+    str = AttributedString.new('abc')
+    str.add_attrs(0..2, bold: true)
+    str.remove_attrs(1..1, :bold)
+
+    spans = str.each_span_with_attrs.to_a
+    assert_equal [
+      ['a', { bold: true }, 0..0],
+      ['b', {}, 1..1],
+      ['c', { bold: true }, 2..2]
+    ], spans
+  end
+
+  def test_array_attributes_accumulate
+    str = AttributedString.new('abc')
+    str.add_arr_attrs(0..1, tag: :x)
+    str.add_arr_attrs(1..2, tag: :y)
+
+    spans = str.each_span_with_attrs.to_a
+    assert_equal [
+      ['a', { tag: [:x] }, 0..0],
+      ['b', { tag: [:x, :y] }, 1..1],
+      ['c', { tag: [:y] }, 2..2]
+    ], spans
+  end
+
+  def test_attachments_do_not_create_new_spans
+    str = AttributedString.new('ab')
+    str.add_attrs(0..1, bold: true)
+    str.add_attachment('img', position: 1)
+
+    spans = str.each_span_with_attrs.to_a
+    assert_equal [
+      ['a', { bold: true }, 0..0],
+      [AttributedString::ATTACHMENT_CHARACTER, {}, 1..1],
+      ['b', { bold: true }, 2..2]
+    ], spans
+  end
+end


### PR DESCRIPTION
## Summary
- optimize inspect with each_span_with_attrs
- handle attribute stacks by entry so spans work with overlapping ranges
- extend each_span_with_attrs unit tests for removals, arrays and attachments
- drop each_char_with_attrs and add more benchmark coverage
- document the new span iterator in README
- clean up inspect implementation
- refactor span iterator for clarity

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_684964a30de88320b9c0afd73089de38